### PR TITLE
Changes to keyword args for Ruby 3

### DIFF
--- a/lib/refile/attachment.rb
+++ b/lib/refile/attachment.rb
@@ -85,8 +85,8 @@ module Refile
         define_method "remote_#{name}_url" do
         end
 
-        define_method "#{name}_url" do |*args|
-          Refile.attachment_url(self, name, *args)
+        define_method "#{name}_url" do |**args|
+          Refile.attachment_url(self, name, **args)
         end
 
         define_method "presigned_#{name}_url" do |expires_in = 900|

--- a/lib/refile/attachment/active_record.rb
+++ b/lib/refile/attachment/active_record.rb
@@ -17,8 +17,8 @@ module Refile
           if send(attacher).present?
             send(attacher).valid?
             errors = send(attacher).errors
-            errors.each do |error|
-              self.errors.add(name, *error)
+            errors.each do |error_type, error|
+              self.errors.add(name, error_type, **(error || {}))
             end
           end
         end

--- a/lib/refile/attachment/multiple_attachments.rb
+++ b/lib/refile/attachment/multiple_attachments.rb
@@ -26,7 +26,7 @@ module Refile
 
           define_method :"#{name}=" do |files|
             cache, files = [files].flatten.partition { |file| file.is_a?(String) }
-            cache = Refile.parse_json(cache.first) || []
+            cache = cache.map { |item| Refile.parse_json(item) || [] }.concat(&:_).flatten
             cache = cache.reject(&:empty?)
             files = files.compact
 

--- a/lib/refile/rails/attachment_helper.rb
+++ b/lib/refile/rails/attachment_helper.rb
@@ -6,13 +6,13 @@ module Refile
       # @see AttachmentHelper#attachment_field
       def attachment_field(method, options = {})
         self.multipart = true
-        @template.attachment_field(@object_name, method, objectify_options(options))
+        @template.attachment_field(@object_name, method, **objectify_options(options))
       end
 
       # @see AttachmentHelper#attachment_cache_field
       def attachment_cache_field(method, options = {})
         self.multipart = true
-        @template.attachment_cache_field(@object_name, method, objectify_options(options))
+        @template.attachment_cache_field(@object_name, method, **objectify_options(options))
       end
     end
 

--- a/refile.gemspec
+++ b/refile.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.1.0"
 
-  spec.add_dependency "sinatra", ">= 2.0.0", "<= 3.0.0"
+  spec.add_dependency "sinatra", ">= 2.0.0", "<= 4.0.0"
+  spec.add_dependency "rest-client", "~> 2"
   spec.add_dependency "mime-types"
 end


### PR DESCRIPTION
## What

This PR implements fixes for issues introduced by separating positional and keyword args in Ruby 3.

## Why

We need to upgrade the Images service to Ruby 3+.

## Anything else

Nicked the changes from this fork: https://github.com/refile/refile/compare/master...iamkyle:refile:master

I took a stab at trying to get the specs running, but it got too hairy trying to figure out how to make the stand-alone TestApp run with Rails 5 on Ruby 3. It's probably best to rewrite it using a newer Rails.